### PR TITLE
get started link on features page fixed

### DIFF
--- a/frontend/src/pages/Features.js
+++ b/frontend/src/pages/Features.js
@@ -43,7 +43,7 @@ function Features(){
             <div className="hero-text">
                     <h1>Take Control of Your Budget</h1>
                     <p>Cash Control helps you manage your finances with ease—locally, securely, and without the cloud.</p>
-                    <a href="#start" className="start-button">Get Started!</a>
+                    <a href="/get-started" className="start-button">Get Started!</a>
                 </div>
         </div>
     );


### PR DESCRIPTION
The Get Started link on the Features page pointed to href=#start but there was no element with id=start on the page so it was effectively unresponsive.  I updated the href to point to /get-started.  I need this link to work for my video to be good.